### PR TITLE
fix: Rename class to firebolt_connector

### DIFF
--- a/connection-dialog.tcd
+++ b/connection-dialog.tcd
@@ -1,4 +1,4 @@
-<connection-dialog class='firebolt'>
+<connection-dialog class='firebolt_connector'>
   <connection-config>
     <authentication-mode value='Basic' />
     <authentication-options>

--- a/connectionResolver.tdr
+++ b/connectionResolver.tdr
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8' ?>
-<tdr class='firebolt'>
+<tdr class='firebolt_connector'>
 	<connection-resolver>
     <connection-builder>
       <script file='connectionBuilder.js'/>

--- a/dialect.tdd
+++ b/dialect.tdd
@@ -2,7 +2,7 @@
 
 <!-- See notes below for definitions that require 2020.3 or newer -->
 <dialect name='FireboltJDBC'
-         class='firebolt'
+         class='firebolt_connector'
          version='18.1'>
   <function-map>
     <function group='numeric' name='ABS' return-type='real'>

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='firebolt' superclass='jdbc' plugin-version='1.0.0' name='Firebolt Connector' version='18.1' min-version-tableau='2020.3'>
+<connector-plugin class='firebolt_connector' superclass='jdbc' plugin-version='1.0.0' name='Firebolt Connector' version='18.1' min-version-tableau='2020.3'>
   <vendor-information>
       <company name="Firebolt"/>
       <support-link url="https://www.firebolt.io/contact"/>
       <driver-download-link url="https://firebolt-publishing-public.s3.amazonaws.com/repo/jdbc/firebolt-jdbc-latest.jar"/>
   </vendor-information>
-  <connection-customization class="firebolt" enabled="true" version="10.0">
+  <connection-customization class="firebolt_connector" enabled="true" version="10.0">
 	<vendor name='Firebolt' />
     <driver name='com.firebolt.FireboltDriver' />
    <customizations>


### PR DESCRIPTION
Renaming the connector class was not backwards-compatible. Reverting the change.